### PR TITLE
feat: default connection IP to SCORE_IP_ADDRESS

### DIFF
--- a/src/Skeleton/ScoreSkeleton.qml
+++ b/src/Skeleton/ScoreSkeleton.qml
@@ -60,7 +60,10 @@ Item {
     // A field to save the IP address + UI zoom
     Settings {
         id: settings
-        property string ip_address: "127.0.0.1"
+        // Default to the address score injects via SCORE_IP_ADDRESS (so the
+        // remote auto-connects when served/launched by score); else localhost.
+        property string ip_address: (score_ip_address && score_ip_address.length > 0)
+                                    ? score_ip_address : "127.0.0.1"
         property real uiScale: 1.0
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,11 @@ int main(int argc, char *argv[])
     const bool tmp_is_mobile = qEnvironmentVariableIsSet("IS_MOBILE") ? qEnvironmentVariableIntValue("IS_MOBILE") > 0 : false;
     engine.rootContext()->setContextProperty("is_mobile", tmp_is_mobile);
 
+    // Score injects its own address via SCORE_IP_ADDRESS when it serves or
+    // launches the remote, so the connection can default to it (empty when
+    // unset, in which case the saved IP / localhost is used).
+    engine.rootContext()->setContextProperty("score_ip_address", qEnvironmentVariable("SCORE_IP_ADDRESS"));
+
     const QUrl url(QStringLiteral("qrc:/main.qml"));
     QObject::connect(&engine, &QQmlApplicationEngine::objectCreated,
                      &app, [url](QObject *obj, const QUrl &objUrl) {


### PR DESCRIPTION
## Summary

When score serves or launches the remote it injects a `SCORE_IP_ADDRESS` environment variable. This exposes it to QML as a `score_ip_address` context property and uses it as the **default** for the persisted `Settings.ip_address` (falling back to `127.0.0.1`), so the remote **auto-connects to score's address** with no typing.

A user's manually-saved IP still persists and wins on later runs — `SCORE_IP_ADDRESS` is a smart default, not an override. The connection dialog and websocket already read `settings.ip_address`, so nothing else changes.

This is the one still-relevant idea from the stale 2021 PR #101; its `remote.html` / `QtLoader` bits are obsolete under Qt 6.12's `qtloader.js` and are intentionally **not** carried over.

## Test
- Builds clean; headless load (offscreen) instantiates the full QML tree with and without `SCORE_IP_ADDRESS` set — `score_ip_address` resolves with no QML errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)