### PR TITLE
fix(windows): build a GUI-subsystem exe so no console window appears

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,12 @@ qt_add_executable(ossia_remote
   fonts.qrc
 )
 
+# Build a GUI-subsystem executable on Windows so no console window is spawned
+# next to the app. qt_add_executable already links Qt's entry-point shim
+# (Qt6::EntryPointPrivate), which supplies the WinMain that forwards to main(),
+# so flipping the subsystem is all that is needed. Ignored on other platforms.
+set_target_properties(ossia_remote PROPERTIES WIN32_EXECUTABLE TRUE)
+
 target_link_libraries(ossia_remote PRIVATE
   Qt6::Quick
   Qt6::Gui


### PR DESCRIPTION
On Windows the app opened with a console window next to the GUI.

`qt_add_executable` produces a **console-subsystem** binary by default, so Windows spawns a console alongside the window. Setting `WIN32_EXECUTABLE TRUE` makes the SDK's llvm-mingw/clang linker target the **windows (GUI) subsystem** instead. No source change is needed: `qt_add_executable` already links Qt's entry-point shim (`Qt6::EntryPointPrivate`), which supplies the `WinMain` that forwards into the existing `main()`. The property is ignored on Linux/macOS/WASM/Android.

Resolves #108 (already closed manually; this is the fix).

## Verification
Reconfigured + built on Linux with Qt 6.11.1 (the property is a no-op off-Windows, confirming the CMake edit is sound). The no-console behavior is observable on the Windows CI artifact from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)