### PR TITLE
feat(ui): set the application window icon

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,7 @@ qt_add_executable(ossia_remote
   main.cpp
   qml.qrc
   fonts.qrc
+  icon.qrc
 )
 
 target_link_libraries(ossia_remote PRIVATE

--- a/src/icon.qrc
+++ b/src/icon.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file alias="ossia_remote.png">../packaging/ossia_remote.png</file>
+    </qresource>
+</RCC>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include <QDirIterator>
 #include <QFont>
 #include <QFontDatabase>
+#include <QIcon>
 
 // Register every bundled font (fonts.qrc -> :/fonts) with the application font
 // database. Mirrors ossia score (src/app/Application.cpp): a blanket walk of the
@@ -33,6 +34,12 @@ int main(int argc, char *argv[])
 #endif
 
     QGuiApplication app(argc, argv);
+
+    // Window-manager / taskbar / dock icon for the running app. Bundled via
+    // icon.qrc so it is embedded in the (static) binary on every platform,
+    // rather than relying on a system icon theme. The Linux .desktop + AppImage
+    // wire the same file for their own launcher integration.
+    app.setWindowIcon(QIcon(QStringLiteral(":/ossia_remote.png")));
 
     qmlRegisterSingletonType(QUrl("qrc:///Utility/Uuid.qml"), "Variable.Global", 1, 0, "Uuid");
     qmlRegisterSingletonType(QUrl("qrc:///Utility/Skin.qml"), "Variable.Global", 1, 0, "Skin");


### PR DESCRIPTION
The running app showed the generic Qt icon in the window manager / taskbar / dock because `setWindowIcon` was never called — only the Linux `.desktop` + AppImage referenced `packaging/ossia_remote.png`.

Embed that 256×256 icon via a new `icon.qrc` so it is compiled into the (static) binary on every platform, and set it from `main()`.

Closes #64.

## Verification
Built with the resource, then linked a probe against the generated `qrc_icon.cpp.o`: `resource_exists=1, icon_isNull=0, 256x256` — the icon loads at runtime, not a null fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)